### PR TITLE
Add jaxb-core as a dependency

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -64,6 +64,11 @@
 		</dependency>
 		<dependency>
 			<groupId>com.sun.xml.bind</groupId>
+			<artifactId>jaxb-core</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.sun.xml.bind</groupId>
 			<artifactId>jaxb-xjc</artifactId>
 			<scope>provided</scope>
 		</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -202,6 +202,11 @@
 			</dependency>
 			<dependency>
 				<groupId>com.sun.xml.bind</groupId>
+				<artifactId>jaxb-core</artifactId>
+				<version>${jaxb.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.sun.xml.bind</groupId>
 				<artifactId>jaxb-xjc</artifactId>
 				<version>${jaxb.version}</version>
 			</dependency>


### PR DESCRIPTION
This change fixes errors due to missing classes during compilation.
Closes highsource/jaxb2-annotate-plugin#27