### PR TITLE
Optimization logging warning: "Could not remove the annotation, target element..."

### DIFF
--- a/plugin/src/main/java/org/jvnet/jaxb2_commons/plugin/removeannotation/RemoveAnnotationPlugin.java
+++ b/plugin/src/main/java/org/jvnet/jaxb2_commons/plugin/removeannotation/RemoveAnnotationPlugin.java
@@ -364,6 +364,9 @@ public class RemoveAnnotationPlugin extends AbstractParameterizablePlugin {
 			}
 		}
 		else {
+			if (annotatable.annotations() == null || annotatable.annotations().isEmpty()) {
+				return;
+			}
 			JClass annotationClass = codeModel.ref(aClass);
 			
 			JAnnotationUse annotationUse = null;


### PR DESCRIPTION
Optimization logging "Could not remove the annotation, target element  is not annotated with annotation class [{0}]." for case annotatable.annotations() return no annotate.